### PR TITLE
05. add functionality for /api/articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env.*
+psqltester*s

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -64,6 +64,29 @@ describe('GET /api/articles/:article_id', () => {
   })
 });
 
+describe('GET /api/articles', () => {
+  test('200: responds with all articles, should an an array of article objects each with relevant properties + datatypes sorted by date in descending order', () => {
+    return request(app)
+    .get("/api/articles")
+    .expect(200)
+    .then(({body: {articles}})=>{
+      expect(articles.length).toBe(13)
+      expect(articles).toBeSortedBy('created_at', {descending: true})
+      articles.forEach((article)=>{
+        expect(article).toEqual(expect.objectContaining({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: expect.any(Number),
+          topic: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+          comment_count: expect.any(Number)
+        }))
+      })
+    })
+  });
+});
 
 //error testing
 describe('error handling', () => {

--- a/app.js
+++ b/app.js
@@ -2,11 +2,12 @@ const express = require("express")
 const app = express()
 app.use(express.json())
 
-const {getEndpoints, getTopics, getArticleByArticleId} = require("./controller")
+const {getEndpoints, getTopics, getArticleByArticleId, getArticles} = require("./controller")
 
 app.get("/api", getEndpoints)
 app.get("/api/topics", getTopics)
 app.get("/api/articles/:article_id", getArticleByArticleId)
+app.get("/api/articles", getArticles)
 
 app.all("/*", (req, res)=>{
     res.status(404).send({error: "Invalid URL!"})

--- a/controller.js
+++ b/controller.js
@@ -1,4 +1,4 @@
-const {readEndpointsData, selectAllTopics, selectArticleByArticleId} = require("./model.js")
+const {readEndpointsData, selectAllTopics, selectArticleByArticleId, selectAllArticles} = require("./model.js")
 
 exports.getEndpoints = (req, res, next) => {
     readEndpointsData().then((endpointsData)=>{
@@ -22,6 +22,16 @@ exports.getArticleByArticleId = (req, res, next) => {
     const {article_id} = req.params
     selectArticleByArticleId(article_id).then((article)=>{
         res.status(200).send({article : article})
+    })
+    .catch((err)=>{
+        next(err)
+    })
+}
+
+exports.getArticles = (req, res, next) => {
+    selectAllArticles()
+    .then((articlesData)=>{
+        res.status(200).send({articles : articlesData})
     })
     .catch((err)=>{
         next(err)

--- a/model.js
+++ b/model.js
@@ -22,3 +22,15 @@ exports.selectArticleByArticleId = (article_id) => {
         return response.rows[0]
     })
 }
+
+exports.selectAllArticles = () => {
+    return db.query(`SELECT title, articles.author, articles.article_id, topic, articles.created_at, articles.votes, article_img_url, 
+        COUNT(comments.comment_id) AS comment_count FROM articles LEFT JOIN comments ON articles.article_id = comments.article_id 
+        GROUP BY articles.article_id ORDER BY articles.created_at DESC;`)
+.then((response)=>{
+    response.rows.map((article)=>{
+        article.comment_count = Number(article.comment_count)
+    })
+    return response.rows
+})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4"
       }
     },
@@ -3268,6 +3269,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7623,6 +7630,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4"
   },
   "dependencies": {
@@ -36,7 +37,7 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all", "jest-sorted"
     ]
   }
 }

--- a/psqltester.md
+++ b/psqltester.md
@@ -1,0 +1,18 @@
+You are now connected to database "nc_news_test" as user "tjw".
+                         title                          |    author     | article_id | topic |     created_at      | votes |                                            article_img_url                                            | comment_count 
+--------------------------------------------------------+---------------+------------+-------+---------------------+-------+-------------------------------------------------------------------------------------------------------+---------------
+ Eight pug gifs that remind me of mitch                 | icellusedkars |          3 | mitch | 2020-11-03 09:12:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             2
+ A                                                      | icellusedkars |          6 | mitch | 2020-10-18 02:00:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             1
+ Sony Vaio; or, The Laptop                              | icellusedkars |          2 | mitch | 2020-10-16 06:03:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ Moustache                                              | butter_bridge |         12 | mitch | 2020-10-11 12:24:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ Another article about Mitch                            | butter_bridge |         13 | mitch | 2020-10-11 12:24:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ UNCOVERED: catspiracy to bring down democracy          | rogersop      |          5 | cats  | 2020-08-03 14:14:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             2
+ Living in the shadow of a great man                    | butter_bridge |          1 | mitch | 2020-07-09 21:11:00 |   100 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |            11
+ They're not exactly dogs, are they?                    | butter_bridge |          9 | mitch | 2020-06-06 10:10:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             2
+ Seven inspirational thought leaders from Manchester UK | rogersop      |         10 | mitch | 2020-05-14 05:15:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ Student SUES Mitch!                                    | rogersop      |          4 | mitch | 2020-05-06 02:14:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ Does Mitch predate civilisation?                       | icellusedkars |          8 | mitch | 2020-04-17 02:08:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ Am I a cat?                                            | icellusedkars |         11 | mitch | 2020-01-15 22:21:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+ Z                                                      | icellusedkars |          7 | mitch | 2020-01-07 14:08:00 |     0 | https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700 |             0
+(13 rows)
+

--- a/psqltester.sql
+++ b/psqltester.sql
@@ -1,0 +1,15 @@
+\c nc_news_test;
+
+SELECT title, 
+articles.author, 
+articles.article_id, 
+topic, 
+articles.created_at,
+articles.votes,
+article_img_url,
+COUNT(comments.comment_id) AS comment_count
+FROM articles 
+LEFT JOIN comments
+ON articles.article_id = comments.article_id 
+GROUP BY articles.article_id
+ORDER BY articles.created_at DESC;


### PR DESCRIPTION
add functionality for /api/articles
counts number of comments per article + returns as comment_count in articles object
testing for length of returned array and properties/datatypes of objects
updated endpoints.json
