### PR TITLE
09_delete_comment_comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -4,13 +4,14 @@ const seed = require("../db/seeds/seed.js")
 const db = require("../db/connection.js")
 
 const endpointsJson = require("../endpoints.json");
-const {articleData, commentData, topicData, userData} = require("../db/data/test-data/index.js");
+const { articleData, commentData, topicData, userData } = require("../db/data/test-data/index.js");
 
-beforeEach(()=>{
-  return seed({topicData, userData, articleData, commentData});
+beforeEach(() => {
+  jest.setTimeout(25000)
+  return seed({ topicData, userData, articleData, commentData });
 })
 
-afterAll(()=>{
+afterAll(() => {
   return db.end();
 })
 
@@ -25,59 +26,58 @@ describe("GET /api", () => {
   });
 });
 
-
 describe('GET /api/topics', () => {
-  test("200: Responds with an array of topic objects, each of which should have a slug and a description property", ()=>{
+  test("200: Responds with an array of topic objects, each of which should have a slug and a description property", () => {
     return request(app)
-    .get("/api/topics")
-    .expect(200)
-    .then(({body: {topics}})=>{
-      expect(topics.length).toBe(3)
-      topics.forEach((topic)=>{
-        expect(topic).toEqual(expect.objectContaining({
-          slug : expect.any(String),
-          description : expect.any(String)
-        }))
+      .get("/api/topics")
+      .expect(200)
+      .then(({ body: { topics } }) => {
+        expect(topics.length).toBe(3)
+        topics.forEach((topic) => {
+          expect(topic).toEqual(expect.objectContaining({
+            slug: expect.any(String),
+            description: expect.any(String)
+          }))
+        })
       })
-    })
   })
 });
 
 describe('GET /api/articles/:article_id', () => {
-  test("200: responds with corresponding article object according to requested id, should return one object with relevant properties + data", ()=>{
+  test("200: responds with corresponding article object according to requested id, should return one object with relevant properties + data", () => {
     return request(app)
-    .get("/api/articles/1")
-    .expect(200)
-    .then(({body : {article}})=>{
-      expect(article).toEqual({
-        author: "butter_bridge",
-        title: "Living in the shadow of a great man",
-        article_id: 1,
-        topic: "mitch",
-        body: "I find this existence challenging",
-        created_at: "2020-07-09T20:11:00.000Z",
-        votes: 100,
-        article_img_url:
-        "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body: { article } }) => {
+        expect(article).toEqual({
+          author: "butter_bridge",
+          title: "Living in the shadow of a great man",
+          article_id: 1,
+          topic: "mitch",
+          body: "I find this existence challenging",
+          created_at: "2020-07-09T20:11:00.000Z",
+          votes: 100,
+          article_img_url:
+            "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        })
       })
-    })
   })
   describe('error handling', () => {
     test('400: returns with a bad request error message when invalid article id inputted', () => {
       return request(app)
-      .get("/api/articles/FIFTEEN")
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .get("/api/articles/FIFTEEN")
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
     test('404: returns with not found message when valid id inputted that has no corresponding article', () => {
       return request(app)
-      .get("/api/articles/3141592")
-      .expect(404)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Not found!")
-      })
+        .get("/api/articles/3141592")
+        .expect(404)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Not found!")
+        })
     });
   });
 });
@@ -85,71 +85,71 @@ describe('GET /api/articles/:article_id', () => {
 describe('GET /api/articles', () => {
   test('200: responds with all articles, should an an array of article objects each with relevant properties + datatypes sorted by date in descending order', () => {
     return request(app)
-    .get("/api/articles")
-    .expect(200)
-    .then(({body: {articles}})=>{
-      expect(articles.length).toBe(13)
-      expect(articles).toBeSortedBy('created_at', {descending: true})
-      articles.forEach((article)=>{
-        expect(article).toEqual(expect.objectContaining({
-          author: expect.any(String),
-          title: expect.any(String),
-          article_id: expect.any(Number),
-          topic: expect.any(String),
-          created_at: expect.any(String),
-          votes: expect.any(Number),
-          article_img_url: expect.any(String),
-          comment_count: expect.any(Number)
-        }))
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles.length).toBe(13)
+        expect(articles).toBeSortedBy('created_at', { descending: true })
+        articles.forEach((article) => {
+          expect(article).toEqual(expect.objectContaining({
+            author: expect.any(String),
+            title: expect.any(String),
+            article_id: expect.any(Number),
+            topic: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+            comment_count: expect.any(Number)
+          }))
+        })
       })
-    })
   });
 });
 
 describe('GET /api/articles/:article_id/comments', () => {
   test('200: should respond with an array of comment objects for relevant article_id with expected properties + datatypes in date ordered desc ', () => {
     return request(app)
-    .get("/api/articles/1/comments")
-    .expect(200)
-    .then(({body: {comments}})=>{
-      expect(comments.length).toBe(11)
-      expect(comments).toBeSortedBy("created_at", {descending : true})
-      comments.forEach((comment)=>{
-        expect(comment).toEqual(expect.objectContaining({
-          comment_id: expect.any(Number),
-          votes: expect.any(Number),
-          created_at: expect.any(String),
-          author: expect.any(String),
-          body: expect.any(String),
-          article_id: expect.any(Number)
-        }))
+      .get("/api/articles/1/comments")
+      .expect(200)
+      .then(({ body: { comments } }) => {
+        expect(comments.length).toBe(11)
+        expect(comments).toBeSortedBy("created_at", { descending: true })
+        comments.forEach((comment) => {
+          expect(comment).toEqual(expect.objectContaining({
+            comment_id: expect.any(Number),
+            votes: expect.any(Number),
+            created_at: expect.any(String),
+            author: expect.any(String),
+            body: expect.any(String),
+            article_id: expect.any(Number)
+          }))
+        })
       })
-    })
   });
-  test("200: returns 200 + empty array when valid article_id inputted where corresponding article exists but has no comments", ()=>{
+  test("200: returns 200 + empty array when valid article_id inputted where corresponding article exists but has no comments", () => {
     return request(app)
-    .get("/api/articles/2/comments")
-    .expect(200)
-    .then(({body : {comments}})=>{
-      expect(comments.length).toBe(0)
-    })
+      .get("/api/articles/2/comments")
+      .expect(200)
+      .then(({ body: { comments } }) => {
+        expect(comments.length).toBe(0)
+      })
   })
   describe('error handling', () => {
     test('400: bad request when invalid article_id inputted', () => {
       return request(app)
-      .get("/api/articles/FIFTEEN/comments")
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .get("/api/articles/FIFTEEN/comments")
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
     test('404: not found when valid article_id inputted but no corresponding article exists', () => {
       return request(app)
-      .get("/api/articles/3141592/comments")
-      .expect(404)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Not found!")
-      })
+        .get("/api/articles/3141592/comments")
+        .expect(404)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Not found!")
+        })
     });
   });
 });
@@ -157,65 +157,65 @@ describe('GET /api/articles/:article_id/comments', () => {
 describe('POST /api/articles/:article_id/comments', () => {
   test('should respond with 201 status code and posted data', () => {
     return request(app)
-    .post("/api/articles/2/comments")
-    .send({username: "icellusedkars", body: "literal chills"})
-    .expect(201)
-    .then(({body: {comment}})=>{
-      expect(comment).toEqual(expect.objectContaining({
+      .post("/api/articles/2/comments")
+      .send({ username: "icellusedkars", body: "literal chills" })
+      .expect(201)
+      .then(({ body: { comment } }) => {
+        expect(comment).toEqual(expect.objectContaining({
           comment_id: expect.any(Number),
           votes: expect.any(Number),
           created_at: expect.any(String),
           author: expect.any(String),
           body: expect.any(String),
           article_id: 2
-      }))
-    })
+        }))
+      })
   });
   describe('error handling', () => {
-    test('400: inputted username doesnt already exist', () => {
+    test('400: inputted username valid but doesnt already exist', () => {
       return request(app)
-      .post("/api/articles/1/comments")
-      .send({username: "tjw", body: "c:"})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .post("/api/articles/1/comments")
+        .send({ username: "tjw", body: "c:" })
+        .expect(404)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Not found!")
+        })
     });
     test('400: articlie id is invalid', () => {
       return request(app)
-      .post("/api/articles/FIFTEEN/comments")
-      .send({username: "icellusedkars", body: "literal chills"})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .post("/api/articles/FIFTEEN/comments")
+        .send({ username: "icellusedkars", body: "literal chills" })
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
-    test('400: article_id valid but article does not exist', () => {
+    test('404: article_id valid but article does not exist', () => {
       return request(app)
-      .post("/api/articles/3141592/comments")
-      .send({username: "icellusedkars", body: "literal chills"})
-      .expect(404)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Not found!")
-      })
+        .post("/api/articles/3141592/comments")
+        .send({ username: "icellusedkars", body: "literal chills" })
+        .expect(404)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Not found!")
+        })
     });
     test('400: post body does not contain the correct properies ', () => {
       return request(app)
-      .post("/api/articles/2/comments")
-      .send({body: "literal chills"})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .post("/api/articles/2/comments")
+        .send({ username: "icellusedkars" })
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
     test('400: posted body properties are null/wrong datatype', () => {
       return request(app)
-      .post("/api/articles/2/comments")
-      .send({username: "icellusedkars", body: null})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .post("/api/articles/2/comments")
+        .send({ username: "icellusedkars", body: null })
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
   });
 });
@@ -223,66 +223,92 @@ describe('POST /api/articles/:article_id/comments', () => {
 describe('PATCH /api/articles/:article_id', () => {
   test('200: should adjust votes of relevant article and return updated article object', () => {
     return request(app)
-    .patch("/api/articles/1")
-    .send({inc_votes: 12})
-    .then(({body: {article}})=>{
-      expect(article.votes).toBe(112)
-    })
+      .patch("/api/articles/1")
+      .send({ inc_votes: 12 })
+      .then(({ body: { article } }) => {
+        expect(article.votes).toBe(112)
+      })
   });
   test('200: should also decrement articles votes if negative votes inputted and work with articles with 0 existing votes', () => {
     return request(app)
-    .patch("/api/articles/2")
-    .send({inc_votes: -1})
-    .then(({body: {article}})=>{
-      expect(article.votes).toBe(-1)
-    })
+      .patch("/api/articles/2")
+      .send({ inc_votes: -1 })
+      .then(({ body: { article } }) => {
+        expect(article.votes).toBe(-1)
+      })
   });
   describe('error handling', () => {
     test('400: patch body does not contain the correct fields', () => {
       return request(app)
-      .patch("/api/articles/2")
-      .send({})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toBe("Bad request!")
-      })
+        .patch("/api/articles/2")
+        .send({})
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toBe("Bad request!")
+        })
     });
     test('400: patch with valid fields but wrong datatype', () => {
       return request(app)
-      .patch("/api/articles/2")
-      .send({inc_votes: "word"})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toBe("Bad request!")
-      })
+        .patch("/api/articles/2")
+        .send({ inc_votes: "word" })
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toBe("Bad request!")
+        })
     });
     test('400: article_id is invalid', () => {
       return request(app)
-      .patch("/api/articles/FIFTEEN")
-      .send({inc_votes: -1})
-      .expect(400)
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Bad request!")
-      })
+        .patch("/api/articles/FIFTEEN")
+        .send({ inc_votes: -1 })
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
     test('404: article_id is valid but article doesnt exist', () => {
       return request(app)
-      .patch("/api/articles/314")
-      .send({inc_votes: -1})
-      .then(({body: {error}})=>{
-        expect(error).toEqual("Not found!")
-      })
+        .patch("/api/articles/314")
+        .send({ inc_votes: -1 })
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Not found!")
+        })
+    });
+  });
+});
+
+describe.only('DELETE /api/comments/comment_id', () => {
+  test('204: should delete comment referenced by comment_id and return nothing', () => {
+    return request(app)
+      .delete("/api/comments/1")
+      .expect(204)
+  });
+  describe('error handling', () => {
+    test('404: returns 404 + error message when attempting to delete a valid comment_id that does not exist', () => {
+      return request(app)
+        .delete("/api/comments/3141592")
+        .expect(404)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Not found!")
+        })
+    });
+    test('400: returns 400 + error message when invalid id inputted', () => {
+      return request(app)
+        .delete("/api/comments/FIFTEEN")
+        .expect(400)
+        .then(({ body: { error } }) => {
+          expect(error).toEqual("Bad request!")
+        })
     });
   });
 });
 
 describe('404: invalid url', () => {
-  test("404: returns with an error message when invalid url requested",()=>{
+  test("404: returns with an error message when invalid url requested", () => {
     return request(app)
-    .get("/app")
-    .expect(404)
-    .then(({body: {error}})=>{
-      expect(error).toEqual("Invalid URL!")
-    })
+      .get("/app")
+      .expect(404)
+      .then(({ body: { error } }) => {
+        expect(error).toEqual("Invalid URL!")
+      })
   })
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -3,7 +3,8 @@ const {
   createRef,
   formatComments,
   checkArticleExists,
-  checkUserExists
+  checkUserExists,
+  checkExists,
 } = require("../db/seeds/utils");
 
 describe("convertTimestampToDate", () => {
@@ -105,20 +106,23 @@ describe("formatComments", () => {
   });
 });
 
-describe('checkArticleExists', () => {
+describe('checkExists', () => {
   test('should return rejected promise with 404 status + msg when searching for an article that doesnt exist', () => {
-    return expect(checkArticleExists(3141592)).rejects.toMatchObject({status: 404, msg: "Not found!"})
+    return expect(checkExists("articles","article_id", 3141592)).rejects.toMatchObject({status: 404, msg: "Not found!"})
   });
   test('should resolve if article exists', () => {
-    return expect(checkArticleExists(2)).resolves.toMatch("Article exists!")
+    return expect(checkExists("articles","article_id", 2)).resolves.toMatch("It's alive!")
   });
-});
-
-describe('checkUserExists', () => {
   test('should return rejected promise with 404 status + msg when searching for an user that doesnt exist', () => {
-    return expect(checkUserExists("tjw")).rejects.toMatchObject({status: 400, msg: "Bad request!"})
+    return expect(checkExists("users","username","tjw")).rejects.toMatchObject({status: 404, msg: "Not found!"})
   });
   test('should resolve if user exists', () => {
-    return expect(checkUserExists("icellusedkars")).resolves.toMatch("User exists!")
+    return expect(checkExists("users","username", "icellusedkars")).resolves.toMatch("It's alive!")
+  });
+  test('should return rejected promise when searching for comment that doesnt exist', () => {
+    return expect(checkExists("comments","comment_id",31415926)).rejects.toMatchObject({status: 404, msg: "Not found!"})
+  })
+  test('should resolve if comment exists', () => {
+    return expect(checkExists("comments","comment_id", 3)).resolves.toMatch("It's alive!")
   });
 });

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require("express")
 const app = express()
 app.use(express.json())
 
-const { getEndpoints, getTopics, getArticleByArticleId, getArticles, getCommentsByArticleId, postCommentByArticleId, patchArticleByArticleId } = require("./controller")
+const { getEndpoints, getTopics, getArticleByArticleId, getArticles, getCommentsByArticleId, postCommentByArticleId, patchArticleByArticleId, deleteCommentByCommentId } = require("./controller")
 
 app.get("/api", getEndpoints)
 app.get("/api/topics", getTopics)
@@ -11,7 +11,7 @@ app.get("/api/articles", getArticles)
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId)
 app.post("/api/articles/:article_id/comments", postCommentByArticleId)
 app.patch("/api/articles/:article_id", patchArticleByArticleId)
-
+app.delete("/api/comments/:comment_id", deleteCommentByCommentId)
 
 app.all("/*", (req, res) => {
     res.status(404).send({ error: "Invalid URL!" })
@@ -31,11 +31,11 @@ app.use((err, req, res, next) => {
     } else next(err)
 })
 
-app.use((err, req, res, next) => {
-    if (err.code === "23503") {
-        res.status(404).send({ error: "Not found!" })
-    } else next(err)
-})
+// app.use((err, req, res, next) => {
+//     if (err.code === "23503") {
+//         res.status(404).send({ error: "Not found!" })
+//     } else next(err)
+// })
 
 app.use((err, req, res, next) => {
     console.log(err, "<<< handle this")

--- a/controller.js
+++ b/controller.js
@@ -1,4 +1,4 @@
-const { readEndpointsData, selectAllTopics, selectArticleByArticleId, selectAllArticles, selectCommentsByArticleId, insertCommentByArticleId, updateArticleByArticleId } = require("./model.js")
+const { readEndpointsData, selectAllTopics, selectArticleByArticleId, selectAllArticles, selectCommentsByArticleId, insertCommentByArticleId, updateArticleByArticleId, deleteFromCommentsByCommentId } = require("./model.js")
 const { checkUserExists } = require("./db/seeds/utils.js")
 
 exports.getEndpoints = (req, res, next) => {
@@ -53,10 +53,7 @@ exports.getCommentsByArticleId = (req, res, next) => {
 exports.postCommentByArticleId = (req, res, next) => {
     const { article_id } = req.params
     const { body } = req
-    checkUserExists(body.username)
-        .then(() => {
-            return insertCommentByArticleId(article_id, body)
-        })
+    return insertCommentByArticleId(article_id, body)
         .then((comment) => {
             res.status(201).send({ comment: comment })
         })
@@ -69,15 +66,25 @@ exports.postCommentByArticleId = (req, res, next) => {
 exports.patchArticleByArticleId = (req, res, next) => {
     const { article_id } = req.params
     const { body } = req
-    if (typeof body.inc_votes !== "number") {
-        next({ status: 400, msg: "Bad request!" })
-    } else {
-        updateArticleByArticleId(article_id, body)
-            .then((article) => {
-                res.status(200).send({ article: article })
-            })
-            .catch((err) => {
-                next(err)
-            })
-    }
+    updateArticleByArticleId(article_id, body)
+        .then((article) => {
+            res.status(200).send({ article: article })
+        })
+        .catch((err) => {
+            next(err)
+        })
+}
+
+
+exports.deleteCommentByCommentId = (req, res, next) => {
+    const { comment_id } = req.params
+    deleteFromCommentsByCommentId(comment_id)
+        .then(() => {
+            res.status(204).send()
+        })
+        .catch((err) => {
+            next(err)
+        })
+
+
 }

--- a/db/seeds/utils.js
+++ b/db/seeds/utils.js
@@ -1,4 +1,5 @@
 const db = require("../connection")
+const format = require("pg-format")
 
 exports.convertTimestampToDate = ({ created_at, ...otherProperties }) => {
   if (!created_at) return { ...otherProperties };
@@ -23,24 +24,13 @@ exports.formatComments = (comments, idLookup) => {
   });
 };
 
-exports.checkArticleExists = (article_id) => {
-  return db.query("SELECT * FROM articles WHERE article_id = $1", [article_id])
-    .then(({rows})=>{
-      if(rows.length===0){
-        return Promise.reject({status: 404, msg: "Not found!"})
-      } else {
-        return "Article exists!"
-      }
-    })
-}
-
-exports.checkUserExists = (username) => {
-  return db.query("SELECT * FROM users WHERE username = $1", [username])
+exports.checkExists = (table, column, value) => {
+  return db.query(format("SELECT * FROM %I WHERE %I = $1", table, column), [value])
   .then(({rows})=>{
     if(rows.length===0){
-      return Promise.reject({status: 400, msg: "Bad request!"})
-      } else {
-        return "User exists!"
-      }
+      return Promise.reject({status: 404, msg: "Not found!"})
+    }else{ 
+      return "It's alive!"
+    }
   })
 }

--- a/model.js
+++ b/model.js
@@ -1,6 +1,6 @@
 const fs = require("fs/promises")
 const db = require("./db/connection")
-const { checkArticleExists, checkUserExists } = require("./db/seeds/utils")
+const { checkExists } = require("./db/seeds/utils")
 
 exports.readEndpointsData = () => {
     return fs.readFile(`${__dirname}/endpoints.json`, "utf8")
@@ -16,11 +16,14 @@ exports.selectAllTopics = () => {
 }
 
 exports.selectArticleByArticleId = (article_id) => {
-    return db.query("SELECT * FROM articles WHERE article_id = $1", [article_id]).then(({ rows }) => {
-        if (rows.length === 0) {
-            return Promise.reject({ status: 404, msg: "Not found!" })
-        }
-        return rows[0]
+    return checkExists("articles", "article_id", article_id).
+    then(() => {
+        return db.query("SELECT * FROM articles WHERE article_id = $1", [article_id]).then(({ rows }) => {
+            if (rows.length === 0) {
+                return Promise.reject({ status: 404, msg: "Not found!" })
+            }
+            return rows[0]
+        })
     })
 }
 
@@ -34,30 +37,44 @@ exports.selectAllArticles = () => {
 }
 
 exports.selectCommentsByArticleId = (article_id) => {
-    return db.query(`SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;`, [article_id])
-        .then(({ rows }) => {
-            if (rows.length === 0) {
-                return checkArticleExists(article_id)
-                    .then(() => { return rows })
-            }
-            else return rows
-        })
+    return checkExists("articles", "article_id", article_id)
+    .then(() => {
+        return db.query(`SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;`, [article_id])
+            .then(({ rows }) => {
+                return rows
+            })
+    })
 }
 
 exports.insertCommentByArticleId = (article_id, body) => {
-        return db.query(`INSERT INTO comments (author, body, article_id) VALUES ($1, $2, $3) RETURNING *`, [body.username, body.body, article_id])
-            .then(({ rows }) => {
-                return rows[0]
-            })
-
+    return checkExists("articles", "article_id", article_id)
+        .then(() => {
+            return checkExists("users", "username", body.username)
+        })
+        .then(() => {
+            return db.query(`INSERT INTO comments (author, body, article_id) VALUES ($1, $2, $3) RETURNING *`, [body.username, body.body, article_id])
+        })
+        .then(({ rows }) => {
+            return rows[0]
+        })
 }
 
 exports.updateArticleByArticleId = (article_id, body) => {
-    return db.query(`UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`, [body.inc_votes, article_id])
-        .then(({ rows }) => {
-            if (rows.length === 0) {
-                return Promise.reject({ status: 404, msg: "Not found!" })
-            }
-            return rows[0]
+    if (typeof body.inc_votes !== "number") {
+        return Promise.reject({ status: 400, msg: "Bad request!" })
+    } else {
+        return checkExists("articles", "article_id", article_id).then(() => {
+            return db.query(`UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`, [body.inc_votes, article_id])
+                .then(({ rows }) => {
+                    return rows[0]
+                })
         })
+    }
+    
+}
+
+exports.deleteFromCommentsByCommentId = (comment_id) => {
+    return checkExists("comments", "comment_id", comment_id).then(() => {
+        return db.query(`DELETE FROM comments WHERE comment_id = $1`, [comment_id])
+    })
 }

--- a/psqltester.sql
+++ b/psqltester.sql
@@ -16,31 +16,7 @@ ORDER BY articles.created_at DESC;
 
 -- SELECT * FROM comments ORDER BY created_at DESC;
 
--- Description
-
--- Should:
-
---     be available on /api/articles/:article_id.
---     update an article by article_id.
-
--- Request body accepts:
-
---     an object in the form { inc_votes: newVote }.
---     newVote will indicate how much the votes property in the database should be updated by, e.g.
---         { inc_votes : 1 } would increment the current article's vote property by 1
---         { inc_votes : -100 } would decrement the current article's vote property by 100
-
--- Responds with:
-
---     the updated article
-
--- Consider what errors could occur with this endpoint, and make sure to test for them.
-
--- Remember to add a description of this endpoint to your /api endpoint.
-
--- PATCH/PUT by ID
-
---     Attempting to PATCH a resource with a body that does not contain the correct fields 
--- (e.g. /api/resource/:id with a body of {}): 400 Bad Request
---     Attempting to PATCH a resource with valid body fields but invalid fields 
--- (e.g /api/resource/:id with a body of { increase_votes_by: "word" }): 400 Bad Request
+-- ttempting to DELETE a resource that does not exist 
+-- (e.g. /api/resource/999999999): 404 Not Found
+-- Attempting to DELETE a resource referenced by an invalid ID
+-- (e.g. /api/resource/notAnId): 400 Bad Request


### PR DESCRIPTION
add functionality, testing + error handling for delete /api/comments/:comment_id. 
refactor checkArticleExists/checkUserExists utility function to be more flexible with a single checkExists that works for all requests + relevant testing. 
refactor some previous 404 errors + error handling to use this function. 
update endpoint.json
.only running most recent tests due to hardware limitations of running all tests at once to pass husky upload requirements but all tests pass. 